### PR TITLE
Add route to fetch all parcels

### DIFF
--- a/server/controllers/parcelController.js
+++ b/server/controllers/parcelController.js
@@ -1,0 +1,13 @@
+import parcels from "../models/parcels";
+
+class ParcelControl {
+    static getAllParcel (req,resp) {
+        return resp.status(200).send({
+            status: 'success',
+            message: 'Parcels returned successfully',
+            parcels: parcels
+        })
+    }
+}
+
+export default ParcelControl;

--- a/server/models/parcels.js
+++ b/server/models/parcels.js
@@ -1,0 +1,6 @@
+const parcels = [
+    {id: 1, title: 'Bicycle Sets', pickUpLocation: 'Nigerian Shores', destination: 'German Shores', price: '40000', presentLocation: 'Egypt', status: 'processing'},
+    {id: 2, title: 'Washing Machine', pickUpLocation: 'Lagos', destination: 'Abuja', price: '25000', presentLocation: 'Lagos', status: 'pending'},
+]
+
+export default parcels;

--- a/server/routes/route.js
+++ b/server/routes/route.js
@@ -1,0 +1,10 @@
+import ParcelControl from "../controllers/parcelController";
+
+const ParcelRoute = (app) => {
+    app.get(
+        '/api/v1/parcels',
+        ParcelControl.getAllParcel
+    )
+}
+
+export default ParcelRoute;

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,10 @@
 import express from 'express';
 import bodyParser from 'body-parser';
+import ParcelRoute from "./routes/route";
 
 const app = express();
+
+ParcelRoute(app);
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended:true}));


### PR DESCRIPTION
#### What does this PR do? ####

- This PR integrates an api route to fetch all parcels on the platform

#### Description of Task to be completed? ####

- When a **GET** request is sent to **localhost:5090/api/v1/parcels**, an array of all parcels placed on the platform should be returned
- A successful request should return a status of 200

#### How should this be manually tested? ####

- Pull this branch **ch-add-route-fetch-all-parcels-161867248** off this repository
- On your command line, run npm install to install all dependencies for this app
- On your command line, run npm start to start the app
- App would run on port **5090**
- Access the endpoint with a **GET** request on **localhost:5090/api/v1/parcels

#### Any background context you want to provide? ####

- This app is a node app and would require nodejs and npm installation on your local machine

#### What are the relevant pivotal tracker stories? ####
[161867248](https://www.pivotaltracker.com/story/show/161867248)

Screenshots (if appropriate)
None

Questions:
None