### PR TITLE
Add route to fetch a specific parcel order

### DIFF
--- a/server/controllers/parcelController.js
+++ b/server/controllers/parcelController.js
@@ -8,6 +8,21 @@ class ParcelControl {
             parcels: parcels
         })
     }
+
+    static getSpecificParcel (req,resp) {
+        const parcel = parcels.find(c => c.id === parseInt(req.params.id));
+        if (!parcel) {
+            return resp.status(404).send({
+                status: 'error',
+                message: 'No parcels exist for the id'
+            });
+        }
+        return resp.status(200).send({
+            status: 'success',
+            message: '1 Parcel returned',
+            parcel: parcel
+        });
+    }
 }
 
 export default ParcelControl;

--- a/server/routes/route.js
+++ b/server/routes/route.js
@@ -5,6 +5,11 @@ const ParcelRoute = (app) => {
         '/api/v1/parcels',
         ParcelControl.getAllParcel
     )
+
+    app.get(
+        '/api/v1/parcels/:id',
+        ParcelControl.getSpecificParcel
+    )
 }
 
 export default ParcelRoute;

--- a/server/test/parcelSpec.js
+++ b/server/test/parcelSpec.js
@@ -17,3 +17,25 @@ describe('/GET /api/v1/parcels', () => {
         })
     })
 })
+
+describe('/GET /api/v1/parcels/:id', () => {
+    it('should return a specific parcel', (done) => {
+        request(server)
+        .get('/api/v1/parcels/1')
+        .end((err,res) => {
+            res.should.have.status(200);
+            res.body.should.be.a('object');
+            done();
+        })
+    })
+
+    it('should return a 404 status when parcel not found', (done) => {
+        request(server)
+        .get('/api/v1/parcels/4')
+        .end((err,res) => {
+            res.should.have.status(404);
+            res.body.should.be.a('object');
+            done();
+        })
+    })
+})


### PR DESCRIPTION
#### What does this PR do? ####

- This PR includes an api route to fetch a specific order on the platform

#### Description of Task to be completed? ####

- When a GET request is sent to **localhost:5090/api/v1/parcels/:id**, an object is returned with order details relative to the id passed
- A successful request  should return a status of 200 

#### How should this be manually tested? ####

- Pull this branch **ch-add-route-fetch-specific-161867700** off this repository
- On your command line, run npm install to install all dependencies for this app
- On your command line, run npm start to start the app
- App would run on port 5090
- Access the endpoint with a GET request on localhost:5090/api/v1/parcelss/:id

#### Any background context you want to provide? ####

- This app is a node app and would require nodejs and npm installation on your local machine

#### What are the relevant pivotal tracker stories? ####
[161867700](https://www.pivotaltracker.com/story/show/161867700)

Screenshots (if appropriate)
None

Questions:
None