### PR TITLE
Add route to cancel a parcel

### DIFF
--- a/server/controllers/parcelController.js
+++ b/server/controllers/parcelController.js
@@ -23,6 +23,30 @@ class ParcelControl {
             parcel: parcel
         });
     }
+
+    static updateParcelStatus (req,resp) {
+        console.log(req.body.status);
+        const parcel = parcels.find(c => c.id === parseInt(req.params.id));
+        if (!parcel) {
+            return resp.status(404).json({
+                status: 'error',
+                message: 'No parcels exist for the id'
+            });
+        }
+        if (!req.body.status) {
+            return resp.status(400).json({
+                status: 'error',
+                message: 'Status field required'
+            });
+        }
+        parcels[req.params.id-1].status = req.body.status;
+        return resp.status(200).json({
+            status: 'success',
+            message: 'Parcel successfully updated',
+            parcel: parcel
+        });
+    }
+
 }
 
 export default ParcelControl;

--- a/server/models/parcels.js
+++ b/server/models/parcels.js
@@ -1,6 +1,6 @@
 const parcels = [
-    {id: 1, title: 'Bicycle Sets', pickUpLocation: 'Nigerian Shores', destination: 'German Shores', price: '40000', presentLocation: 'Egypt', status: 'processing'},
-    {id: 2, title: 'Washing Machine', pickUpLocation: 'Lagos', destination: 'Abuja', price: '25000', presentLocation: 'Lagos', status: 'pending'},
+    {user_id: 1, parcel_id: 1,  title: 'Bicycle Sets', pickUpLocation: 'Nigerian Shores', destination: 'German Shores', price: '40000', presentLocation: 'Egypt', status: 'processing'},
+    {user_id: 1,  parcel_id: 1, title: 'Washing Machine', pickUpLocation: 'Lagos', destination: 'Abuja', price: '25000', presentLocation: 'Lagos', status: 'pending'},
 ]
 
 export default parcels;

--- a/server/routes/route.js
+++ b/server/routes/route.js
@@ -10,6 +10,11 @@ const ParcelRoute = (app) => {
         '/api/v1/parcels/:id',
         ParcelControl.getSpecificParcel
     )
+
+    app.put(
+        '/api/v1/parcels/:id',
+        ParcelControl.updateParcelStatus
+    )
 }
 
 export default ParcelRoute;

--- a/server/test/parcelSpec.js
+++ b/server/test/parcelSpec.js
@@ -38,4 +38,48 @@ describe('/GET /api/v1/parcels/:id', () => {
             done();
         })
     })
+
+})
+
+describe('/PUT /api/v1/parcels', () => {
+        it('should update the status of a parcel', (done) => {
+            const obj = {
+                status: 'processing'
+            }
+            request(server)
+            .put('/api/v1/parcels/'+2)
+            .send(obj)
+            .end((err,res) => {
+                res.should.have.status(200);
+                res.body.should.be.a('object');
+                done();
+            })
+        })
+        it('should return a 404 error, parcel not found', (done) => {
+            const status = {
+                status: 'processing'
+            }
+            request(server)
+            .put('/api/v1/parcels/5')
+            .send(status)
+            .end((err,res) => {
+                res.should.have.status(404);
+                res.body.should.be.a('object');
+                done();
+            })
+        })
+        it('should return a 400 error, status field required', (done) => {
+            const status = {
+            }
+            request(server)
+            .put('/api/v1/parcels/1')
+            .send(status)
+            .end((err,res) => {
+                res.should.have.status(400);
+                res.body.should.be.a('object');
+                done();
+            })
+        })
+   
+
 })


### PR DESCRIPTION
#### What does this PR do? ####

- This PR includes an api route to update the status of  a parcel on the platform

#### Description of Task to be completed? ####

- When a PUT request is sent to **localhost:5090/api/v1/parcels/:id**, A parcel status is updated on the platform 
- A successful request  should return a status of 200 

#### How should this be manually tested? ####

- Pull this branch **ch-add-route-cancel-parcel-161951614** off this repository
- On your command line, run npm install to install all dependencies for this app
- On your command line, run npm start to start the app
- App would run on port 5090
- Access the endpoint with a PUT request on localhost:5090/api/v1/parcels/:id

#### Any background context you want to provide? ####

- This app is a node app and would require nodejs and npm installation on your local machine

#### What are the relevant pivotal tracker stories? ####
[161951614](https://www.pivotaltracker.com/story/show/161951614)

Screenshots (if appropriate)
None

Questions:
None